### PR TITLE
fixed UI bugs

### DIFF
--- a/src/modules/cluster/cluster-list/cluster-list.html
+++ b/src/modules/cluster/cluster-list/cluster-list.html
@@ -21,7 +21,7 @@
                         <select ng-init="clusterCntrl.orderBy = 'name'" ng-model="clusterCntrl.orderBy" ng-disabled="clusterCntrl.clusterList.length === 0" ng-change="clusterCntrl.displayArg()">
                             <option value="name" class="selected">Name</option>
                             <option value="status">Status</option>
-                            <option value="storage['percent_used']">Utilization</option>
+                            <option value="utilization['percent_used']">Utilization</option>
                         </select>
                     </div>
                     <button ng-init="clusterCntrl.ascOrder = ''" ng-disabled="clusterCntrl.clusterList.length === 0" class="btn btn-link" type="button">
@@ -64,7 +64,7 @@
             </div>
             <div class="col-md-1 text-center cluster-name bold-text counts" ng-click="clusterCntrl.goToClusterDetail(cluster.id)">{{cluster.name}}</div>
             <div class="col-md-3">
-                <donut-chart id="" id="storage-donut-chart{{$index}}" class="list-view-pf-additional-info-item" chart-data="cluster.storage"></donut-chart>
+                <donut-chart id="" id="utilization-donut-chart{{$index}}" class="list-view-pf-additional-info-item" chart-data="cluster.utilization"></donut-chart>
             </div>
             <div class="col-md-3">
                 {{cluster.iops}}
@@ -77,8 +77,13 @@
             </div>
             <div class="col-md-1">
                 <div class="list-view-pf-additional-info-item list-view-pf-additional-info-item-stacked">
-                    <div class="bold-text">Pools</div>
-                    <h5 class="pull-left counts">{{cluster.poolCount}}</h5>
+                    <div class="bold-text">
+                        <span ng-if="cluster.sds_name === 'ceph'">Pools</span>
+                        <span ng-if="cluster.sds_name === 'glusterfs'">File Shares</span>
+                    </div>
+                    <h5 class="pull-left counts">
+                        {{cluster.poolOrFileShareCount}}
+                    </h5>
                 </div>
             </div>
             <div class="col-md-1">

--- a/src/modules/rbd/create-rbd/create-rbd.js
+++ b/src/modules/rbd/create-rbd/create-rbd.js
@@ -10,9 +10,11 @@
         var vm = this,
             selectedPool,
             poolList,
-            rbdList;
+            rbdList,
+            index;
 
         vm.step = 1;
+        vm.clusterList = [];
         vm.updateStep = updateStep;
         vm.updateRBDName = updateRBDName;
         vm.isSizeGreater = isSizeGreater;
@@ -88,12 +90,20 @@
         function init() {
 
             if (typeof $rootScope.clusterData !== "undefined") {
-                vm.clusterList = $rootScope.clusterData.clusters;
+                for(index = 0 ; index < $rootScope.clusterData.clusters.length ; index++) {
+                    if($rootScope.clusterData.clusters[index].sds_name === 'ceph') {
+                        vm.clusterList.push($rootScope.clusterData.clusters[index]);
+                    }
+                }
             } else {
                 utils.getObjectList("Cluster")
                     .then(function(data) {
                         $rootScope.clusterData = data;
-                        vm.clusterList = $rootScope.clusterData.clusters;
+                        for(index = 0 ; index < $rootScope.clusterData.clusters.length ; index++) {
+                            if($rootScope.clusterData.clusters[index].sds_name === 'ceph') {
+                                vm.clusterList.push($rootScope.clusterData.clusters[index]);
+                            }
+                        }
                     });
             }
 


### PR DESCRIPTION
- added the utilization donut chart for ceph cluster - utilization data is coming from api now for ceph cluster.
- if cluster is ceph , than we need to show pool count and if cluster is gluster than we need to show file shares count in ui.
- we need to add associated host count in cluster list page for both ceph and gluster cluster
- only ceph cluster should be detect in drop-down in case of create rbd and first one should be selected by default.

Signed-off-by: kamleshKumarVerma <kaverma@redhat.com>